### PR TITLE
QA fixes: transfer event extraction for zaps + safe indexing for token amount extraction

### DIFF
--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -11,7 +11,7 @@ dataSources:
     source:
       package:
         moduleName: graph_out
-        file: curve-sps-v0.1.18-alpha.spkg
+        file: curve-sps-v0.1.19-alpha.spkg
     mapping:
       kind: substreams/graph-entities
       apiVersion: 0.0.5

--- a/substreams.yaml
+++ b/substreams.yaml
@@ -1,7 +1,7 @@
 specVersion: v0.1.0
 package:
   name: curve_sps
-  version: v0.1.18-alpha
+  version: v0.1.19-alpha
 
 imports:
   graph: https://github.com/streamingfast/substreams-sink-subgraph/releases/download/v0.1.0/substreams-sink-subgraph-protodefs-v0.1.0.spkg


### PR DESCRIPTION
This PR contains:

- Fix to the transfer event extraction for withdraw one events. Some zaps meant the criteria we used to extract the transfer was not working. This caused liquidity removals to be missed.
- Fix the indexing of token amounts for the RemoveLiquidity6. This now ensures we are only indexing up to the amount of input tokens, and not relying on what is emitted from the event. The issue was caused by empty amounts being emitted from the event, say a `Vec<BigInt>` of length 5, although there are only 2 input tokens.
- Bumped release version.